### PR TITLE
add missing lua functions

### DIFF
--- a/DefaultMod/Includes/color.lua
+++ b/DefaultMod/Includes/color.lua
@@ -6,7 +6,9 @@ COLOR.__index = COLOR
 	Register our metatable to make it accessible using FindMetaTable
 -----------------------------------------------------------]]
 
-debug.getregistry().Color = COLOR
+if debug then
+   debug.getregistry().Color = COLOR
+end
 
 --[[---------------------------------------------------------
 	To easily create a color table

--- a/DefaultMod/Includes/string.lua
+++ b/DefaultMod/Includes/string.lua
@@ -1,5 +1,6 @@
 local string = string
 local math = math
+local function isnumber(t) return type(t) == 'number' end
 
 --[[---------------------------------------------------------
 	Name: string.ToTable( string )

--- a/DefaultMod/Includes/table.lua
+++ b/DefaultMod/Includes/table.lua
@@ -1,3 +1,10 @@
+local function istable(t) return type(t) == 'table' end
+local function isstring(t) return type(t) == 'string' end
+local function isnumber(t) return type(t) == 'number' end
+local function isbool(t) return type(t) == 'boolean' end
+local function ivector(t) return Vector ~= nil and getmetatable(t) == Vector end
+local function isangle(t) return Angle ~= nil and getmetatable(t) == Angle end
+
 --[[---------------------------------------------------------
 	Name: Inherit( t, base )
 	Desc: Copies any missing data from base to t


### PR DESCRIPTION
The type checking functions used in `table.lua` and `string.lua` did not exist, which would cause errors when using `table.ToString` for example (useful for debugging purposes).

Also the `debug` variable might not exist, which makes loading `color.lua` fail, although it doesn't seem to be used.