### PR TITLE
Expose almost all modding API to Lua

### DIFF
--- a/DefaultMod/DefaultMod.csproj
+++ b/DefaultMod/DefaultMod.csproj
@@ -80,6 +80,7 @@
       <DependentUpon>formLoader.cs</DependentUpon>
     </Compile>
     <Compile Include="Analytics.cs" />
+    <Compile Include="GooseProxy.cs" />
     <Compile Include="Keys.cs" />
     <Compile Include="Lua\Hook.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/DefaultMod/GooseProxy.cs
+++ b/DefaultMod/GooseProxy.cs
@@ -1,0 +1,152 @@
+﻿// 
+// GooseProxy.cs
+// Copyright (C) 2020 Jesús A. Álvarez
+// This file is dual-licensed under the GNU GPL 3.0 and MIT Licenses
+// 
+// MIT License
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// GNU GENERAL PUBLIC LICENSE
+// Version 3, 29 June 2007
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// 
+using System.Linq;
+using System.Reflection;
+using GooseShared;
+using MoonSharp.Interpreter;
+using SamEngine;
+
+namespace GooseLua
+{
+    class VectorProxy
+    {
+        private readonly object obj;
+        private readonly FieldInfo field;
+
+        [MoonSharpHidden]
+        public VectorProxy(object obj, FieldInfo field)
+        {
+            this.obj = obj;
+            this.field = field;
+        }
+
+        private Vector2 Vector
+        {
+            get => (Vector2)field.GetValue(obj);
+        }
+
+        public float X
+        {
+            get => Vector.x;
+            set => field.SetValue(obj, new Vector2(value, Vector.y));
+        }
+
+        public float Y
+        {
+            get => Vector.y;
+            set => field.SetValue(obj, new Vector2(Vector.x, value));
+        }
+    }
+
+    class GooseProxy
+    {
+        private Script script => _G.LuaState;
+        private GooseEntity goose => _G.goose;
+
+        [MoonSharpHidden]
+        private Vector2 ToVector(DynValue value)
+        {
+            double x, y;
+            switch (value.Type)
+            {
+                case DataType.Table when value.Table.Get("x").IsNotNil() && value.Table.Get("y").IsNotNil():
+                    x = value.Table.Get("x").Number;
+                    y = value.Table.Get("y").Number;
+                    break;
+                case DataType.Table when value.Table.Get(1).IsNotNil() && value.Table.Get(2).IsNotNil() && value.Table.Length == 2:
+                    x = value.Table.Get(1).Number;
+                    y = value.Table.Get(2).Number;
+                    break;
+                case DataType.Tuple when value.Tuple.Length == 2:
+                    x = value.Tuple[0].Number;
+                    y = value.Tuple[1].Number;
+                    break;
+                default:
+                    throw new ScriptRuntimeException("Cannot convert value to vector: " + value.ToDebugPrintString());
+            }
+            return new Vector2((float)x, (float)y);
+        }
+
+        public DynValue Position
+        {
+            get => DynValue.FromObject(script, new VectorProxy(goose, typeof(GooseEntity).GetField("position")));
+            set => goose.position = ToVector(value);
+        }
+        public void SetPosition(float x, float y) => goose.position = new Vector2(x, y);
+
+        public DynValue Target
+        {
+            get => DynValue.FromObject(script, new VectorProxy(goose, typeof(GooseEntity).GetField("targetPos")));
+            set => goose.targetPos = ToVector(value);
+        }
+        public void SetTarget(float x, float y) => goose.targetPos = new Vector2(x, y);
+
+        public string[] Tasks { get => GetTasks(); }
+        public string[] GetTasks() => API.TaskDatabase.getAllLoadedTaskIDs();
+
+        public string Task
+        {
+            get => GetTask();
+            set => SetTask(value, true);
+        }
+        public string GetTask()
+        {
+            if (goose.currentTask == -1)
+            {
+                return null;
+            }
+            return API.TaskDatabase.getAllLoadedTaskIDs()[goose.currentTask];
+        }
+
+        public void SetTask(string taskName, bool honk = true)
+        {
+            string[] tasks = API.TaskDatabase.getAllLoadedTaskIDs();
+            if (tasks.Any(taskName.Equals))
+            {
+                API.Goose.setCurrentTaskByID(goose, taskName, honk);
+            } else
+            {
+                throw new ScriptRuntimeException("Unknown task \"" + taskName + "\".");
+            }
+        }
+    }
+}

--- a/DefaultMod/GooseProxy.cs
+++ b/DefaultMod/GooseProxy.cs
@@ -1,4 +1,4 @@
-﻿// 
+// 
 // GooseProxy.cs
 // Copyright (C) 2020 Jesús A. Álvarez
 // This file is dual-licensed under the GNU GPL 3.0 and MIT Licenses

--- a/DefaultMod/GooseProxy.cs
+++ b/DefaultMod/GooseProxy.cs
@@ -47,43 +47,180 @@ using SamEngine;
 
 namespace GooseLua
 {
+    class GooseProxy
+    {
+        private Script script => _G.LuaState;
+        private GooseEntity goose => _G.goose;
+
+        public static void Register()
+        {
+            UserData.RegisterType<GooseProxy>();
+            UserData.RegisterType<VectorProxy>();
+            UserData.RegisterType<RigProxy>();
+            UserData.RegisterType<ProceduralFeetsProxy>();
+        }
+
+        public DynValue Position
+        {
+            get => VectorProxy.ToDynValue(script, goose, typeof(GooseEntity).GetField("position"));
+            set => goose.position = VectorProxy.ToVector(value);
+        }
+
+        public DynValue Velocity
+        {
+            get => VectorProxy.ToDynValue(script, goose, typeof(GooseEntity).GetField("velocity"));
+            set => goose.velocity = VectorProxy.ToVector(value);
+        }
+
+        public float Direction
+        {
+            get => goose.direction;
+            set => goose.direction = value;
+        }
+
+        public DynValue TargetDirection
+        {
+            get => VectorProxy.ToDynValue(script, goose, typeof(GooseEntity).GetField("targetDirection"));
+            set => goose.targetDirection = VectorProxy.ToVector(value);
+        }
+
+        public bool ExtendingNeck
+        {
+            get => goose.extendingNeck;
+            set => goose.extendingNeck = value;
+        }
+
+        public DynValue Target
+        {
+            get => VectorProxy.ToDynValue(script, goose, typeof(GooseEntity).GetField("targetPos"));
+            set => goose.targetPos = VectorProxy.ToVector(value);
+        }
+
+        public float CurrentSpeed
+        {
+            get => goose.currentSpeed;
+            set => goose.currentSpeed = value;
+        }
+
+        public float CurrentAcceleration
+        {
+            get => goose.currentAcceleration;
+            set => goose.currentAcceleration = value;
+        }
+
+        public float StepInterval
+        {
+            get => goose.stepInterval;
+            set => goose.stepInterval = value;
+        }
+
+        public bool CanDecelerateImmediately
+        {
+            get => goose.canDecelerateImmediately;
+            set => goose.canDecelerateImmediately = value;
+        }
+
+        public float Time
+        {
+            get => SamEngine.Time.time;
+        }
+
+        #region Foot Marks
+        public float TrackMudEndTime
+        {
+            get => goose.trackMudEndTime;
+            set => goose.trackMudEndTime = value;
+        }
+
+        public void AddFootMark(DynValue position)
+        {
+            goose.footMarks[goose.footMarkIndex].time = SamEngine.Time.time;
+            goose.footMarks[goose.footMarkIndex].position = VectorProxy.ToVector(position);
+            goose.footMarkIndex++;
+            if (goose.footMarkIndex >= goose.footMarks.Length)
+            {
+                goose.footMarkIndex = 0;
+            }
+        }
+
+        public void ClearFootMarks()
+        {
+            for (int i=0; i < goose.footMarks.Length; i++) 
+            {
+                goose.footMarks[i].time = 0f;
+            }
+        }
+        #endregion
+
+        public DynValue Rig
+        {
+            get => DynValue.FromObject(script, new RigProxy(script, goose.rig));
+            set => UpdateRig(value);
+        }
+
+        private void UpdateRig(DynValue value)
+        {
+            System.Console.WriteLine("Updating rig");
+        }
+
+        #region Tasks
+        public string[] Tasks { get => GetTasks(); }
+        
+        public string Task
+        {
+            get => GetTask();
+            set => SetTask(value, true);
+        }
+
+        public void SetTask(string taskName, bool honk = true)
+        {
+            string[] tasks = API.TaskDatabase.getAllLoadedTaskIDs();
+            if (tasks.Any(taskName.Equals))
+            {
+                API.Goose.setCurrentTaskByID(goose, taskName, honk);
+            } else
+            {
+                throw new ScriptRuntimeException("Unknown task \"" + taskName + "\".");
+            }
+        }
+        #endregion
+
+        #region Deprecated
+        // Deprecated functions for compatibility
+        public string[] GetTasks() => API.TaskDatabase.getAllLoadedTaskIDs();
+        public void SetPosition(float x, float y) => goose.position = new Vector2(x, y);
+        public void SetTarget(float x, float y) => goose.targetPos = new Vector2(x, y);
+        public string GetTask()
+        {
+            if (goose.currentTask == -1)
+            {
+                return null;
+            }
+            return API.TaskDatabase.getAllLoadedTaskIDs()[goose.currentTask];
+        }
+        #endregion
+    }
+
     class VectorProxy
     {
         private readonly object obj;
         private readonly FieldInfo field;
 
         [MoonSharpHidden]
-        public VectorProxy(object obj, FieldInfo field)
+        private VectorProxy(object obj, FieldInfo field)
         {
             this.obj = obj;
             this.field = field;
         }
 
-        private Vector2 Vector
+        [MoonSharpHidden]
+        internal static DynValue ToDynValue(Script script, object obj, FieldInfo field)
         {
-            get => (Vector2)field.GetValue(obj);
+            return DynValue.FromObject(script, new VectorProxy(obj, field));
         }
-
-        public float X
-        {
-            get => Vector.x;
-            set => field.SetValue(obj, new Vector2(value, Vector.y));
-        }
-
-        public float Y
-        {
-            get => Vector.y;
-            set => field.SetValue(obj, new Vector2(Vector.x, value));
-        }
-    }
-
-    class GooseProxy
-    {
-        private Script script => _G.LuaState;
-        private GooseEntity goose => _G.goose;
 
         [MoonSharpHidden]
-        private Vector2 ToVector(DynValue value)
+        internal static Vector2 ToVector(DynValue value)
         {
             double x, y;
             switch (value.Type)
@@ -106,47 +243,178 @@ namespace GooseLua
             return new Vector2((float)x, (float)y);
         }
 
-        public DynValue Position
+        private Vector2 Vector
         {
-            get => DynValue.FromObject(script, new VectorProxy(goose, typeof(GooseEntity).GetField("position")));
-            set => goose.position = ToVector(value);
-        }
-        public void SetPosition(float x, float y) => goose.position = new Vector2(x, y);
-
-        public DynValue Target
-        {
-            get => DynValue.FromObject(script, new VectorProxy(goose, typeof(GooseEntity).GetField("targetPos")));
-            set => goose.targetPos = ToVector(value);
-        }
-        public void SetTarget(float x, float y) => goose.targetPos = new Vector2(x, y);
-
-        public string[] Tasks { get => GetTasks(); }
-        public string[] GetTasks() => API.TaskDatabase.getAllLoadedTaskIDs();
-
-        public string Task
-        {
-            get => GetTask();
-            set => SetTask(value, true);
-        }
-        public string GetTask()
-        {
-            if (goose.currentTask == -1)
-            {
-                return null;
-            }
-            return API.TaskDatabase.getAllLoadedTaskIDs()[goose.currentTask];
+            get => (Vector2)field.GetValue(obj);
         }
 
-        public void SetTask(string taskName, bool honk = true)
+        public float X
         {
-            string[] tasks = API.TaskDatabase.getAllLoadedTaskIDs();
-            if (tasks.Any(taskName.Equals))
-            {
-                API.Goose.setCurrentTaskByID(goose, taskName, honk);
-            } else
-            {
-                throw new ScriptRuntimeException("Unknown task \"" + taskName + "\".");
-            }
+            get => Vector.x;
+            set => field.SetValue(obj, new Vector2(value, Vector.y));
         }
+
+        public float Y
+        {
+            get => Vector.y;
+            set => field.SetValue(obj, new Vector2(Vector.x, value));
+        }
+    }
+
+    class RigProxy
+    {
+        private Rig rig;
+        private Script script;
+
+        [MoonSharpHidden]
+        internal RigProxy(Script script, Rig rig)
+        {
+            this.script = script;
+            this.rig = rig;
+            this.feets = DynValue.FromObject(script, new ProceduralFeetsProxy(script, rig.feets));
+        }
+
+        /* Feets */
+        public DynValue feets;
+
+        /* Under Body*/
+        public const int UnderBodyRadius = Rig.UnderBodyRadius;
+        public const int UnderBodyLength = Rig.UnderBodyLength;
+        public const int UnderBodyElevation = Rig.UnderBodyElevation;
+        public DynValue underbodyCenter
+        {
+            get => VectorProxy.ToDynValue(script, rig, typeof(Rig).GetField("underbodyCenter"));
+            set => rig.underbodyCenter = VectorProxy.ToVector(value);
+        }
+
+        /* Body */
+        public const int BodyRadius = Rig.BodyRadius;
+        public const int BodyLength = Rig.BodyLength;
+        public const int BodyElevation = Rig.BodyElevation;
+        public DynValue bodyCenter
+        {
+            get => VectorProxy.ToDynValue(script, rig, typeof(Rig).GetField("bodyCenter"));
+            set => rig.bodyCenter = VectorProxy.ToVector(value);
+        }
+
+        /* Necc */
+        // Properties
+        public const int NeccRadius = Rig.NeccRadius;
+        public const int NeccHeight1 = Rig.NeccHeight1;
+        public const int NeccExtendForward1 = Rig.NeccExtendForward1;
+        public const int NeccHeight2 = Rig.NeccHeight2;
+        public const int NeccExtendForward2 = Rig.NeccExtendForward2;
+        public float neckLerpPercent
+        {
+            get => rig.neckLerpPercent;
+            set => rig.neckLerpPercent = value;
+        }
+        public DynValue neckCenter
+        {
+            get => VectorProxy.ToDynValue(script, rig, typeof(Rig).GetField("neckCenter"));
+            set => rig.neckCenter = VectorProxy.ToVector(value);
+        }
+        public DynValue neckBase
+        {
+            get => VectorProxy.ToDynValue(script, rig, typeof(Rig).GetField("neckBase"));
+            set => rig.neckBase = VectorProxy.ToVector(value);
+        }
+        public DynValue neckHeadPoint
+        {
+            get => VectorProxy.ToDynValue(script, rig, typeof(Rig).GetField("neckHeadPoint"));
+            set => rig.neckHeadPoint = VectorProxy.ToVector(value);
+        }
+
+        /* Head */
+        public const int HeadRadius1 = Rig.HeadRadius1;
+        public const int HeadLength1 = Rig.HeadLength1;
+        public const int HeadRadius2 = Rig.HeadRadius2;
+        public const int HeadLength2 = Rig.HeadLength2;
+        public DynValue head1EndPoint
+        {
+            get => VectorProxy.ToDynValue(script, rig, typeof(Rig).GetField("head1EndPoint"));
+            set => rig.head1EndPoint = VectorProxy.ToVector(value);
+        }
+        public DynValue head2EndPoint
+        {
+            get => VectorProxy.ToDynValue(script, rig, typeof(Rig).GetField("head2EndPoint"));
+            set => rig.head2EndPoint = VectorProxy.ToVector(value);
+        }
+
+        /* Eyes */
+        public const int EyeRadius = Rig.EyeRadius;
+        public const int EyeElevation = Rig.EyeElevation;
+        public const float IPD = Rig.IPD;
+        public const float EyesForward = Rig.EyesForward;
+    }
+
+    public class ProceduralFeetsProxy
+    {
+        private Script script;
+        private ProceduralFeets feets;
+
+        [MoonSharpHidden]
+        public ProceduralFeetsProxy(Script script, ProceduralFeets feets)
+        {
+            this.script = script;
+            this.feets = feets;
+        }
+
+        public DynValue lFootPos
+        {
+            get => VectorProxy.ToDynValue(script, feets, typeof(ProceduralFeets).GetField("lFootPos"));
+            set => feets.lFootPos = VectorProxy.ToVector(value);
+        }
+
+        public DynValue rFootPos
+        {
+            get => VectorProxy.ToDynValue(script, feets, typeof(ProceduralFeets).GetField("rFootPos"));
+            set => feets.rFootPos = VectorProxy.ToVector(value);
+        }
+
+        public float lFootMoveTimeStart
+        {
+            get => feets.lFootMoveTimeStart;
+            set => feets.lFootMoveTimeStart = value;
+        }
+
+        public float rFootMoveTimeStart
+        {
+            get => feets.rFootMoveTimeStart;
+            set => feets.rFootMoveTimeStart = value;
+        }
+
+        public DynValue lFootMoveOrigin
+        {
+            get => VectorProxy.ToDynValue(script, feets, typeof(ProceduralFeets).GetField("lFootMoveOrigin"));
+            set => feets.lFootMoveOrigin = VectorProxy.ToVector(value);
+        }
+
+        public DynValue rFootMoveOrigin
+        {
+            get => VectorProxy.ToDynValue(script, feets, typeof(ProceduralFeets).GetField("rFootMoveOrigin"));
+            set => feets.rFootMoveOrigin = VectorProxy.ToVector(value);
+        }
+
+        public DynValue lFootMoveDir
+        {
+            get => VectorProxy.ToDynValue(script, feets, typeof(ProceduralFeets).GetField("lFootMoveDir"));
+            set => feets.lFootMoveDir = VectorProxy.ToVector(value);
+        }
+
+        public DynValue rFootMoveDir
+        {
+            get => VectorProxy.ToDynValue(script, feets, typeof(ProceduralFeets).GetField("rFootMoveDir"));
+            set => feets.rFootMoveDir = VectorProxy.ToVector(value);
+        }
+
+        public int feetDistanceApart
+        {
+            get => feets.feetDistanceApart;
+            set => feets.feetDistanceApart = value;
+        }
+
+        public const float wantStepAtDistance = ProceduralFeets.wantStepAtDistance;
+        public const float overshootFraction = ProceduralFeets.overshootFraction;
     }
 }

--- a/DefaultMod/GooseProxy.cs
+++ b/DefaultMod/GooseProxy.cs
@@ -49,15 +49,26 @@ namespace GooseLua
 {
     class GooseProxy
     {
-        private Script script => _G.LuaState;
+        private readonly Script script;
         private GooseEntity goose => _G.goose;
 
+        [MoonSharpHidden]
+        public GooseProxy(Script script)
+        {
+            this.script = script;
+            script.Globals["Speed"] = UserData.CreateStatic<GooseEntity.SpeedTiers>();
+            script.Globals["ScreenDirection"] = UserData.CreateStatic<ScreenDirection>();
+        }
+
+        [MoonSharpHidden]
         public static void Register()
         {
             UserData.RegisterType<GooseProxy>();
             UserData.RegisterType<VectorProxy>();
             UserData.RegisterType<RigProxy>();
             UserData.RegisterType<ProceduralFeetsProxy>();
+            UserData.RegisterType<ScreenDirection>();
+            UserData.RegisterType<GooseEntity.SpeedTiers>();
         }
 
         public DynValue Position
@@ -163,7 +174,7 @@ namespace GooseLua
             System.Console.WriteLine("Updating rig");
         }
 
-        #region Tasks
+        #region Goose Functions
         public string[] Tasks { get => GetTasks(); }
         
         public string Task
@@ -182,6 +193,41 @@ namespace GooseLua
             {
                 throw new ScriptRuntimeException("Unknown task \"" + taskName + "\".");
             }
+        }
+
+        public void ChooseRandomTask()
+        {
+            API.Goose.chooseRandomTask(goose);
+        }
+
+        public void Roam()
+        {
+            API.Goose.setTaskRoaming(goose);
+        }
+
+        public void Honk()
+        {
+            API.Goose.playHonckSound();
+        }
+
+        public void SetSpeed(GooseEntity.SpeedTiers tier)
+        {
+            API.Goose.setSpeed(goose, tier);
+        }
+
+        public ScreenDirection SetTargetOffscreen(bool canExitTop = false)
+        {
+            return API.Goose.setTargetOffscreen(goose, canExitTop);
+        }
+
+        public bool IsGooseAtTarget(float distance)
+        {
+            return API.Goose.isGooseAtTarget(goose, distance);
+        }
+
+        public float DistanceToTarget
+        {
+            get => API.Goose.getDistanceToTarget(goose);
         }
         #endregion
 
@@ -275,7 +321,7 @@ namespace GooseLua
         }
 
         /* Feets */
-        public DynValue feets;
+        public DynValue feets { get; private set; }
 
         /* Under Body*/
         public const int UnderBodyRadius = Rig.UnderBodyRadius;

--- a/DefaultMod/Includes/table.lua
+++ b/DefaultMod/Includes/table.lua
@@ -2,7 +2,7 @@ local function istable(t) return type(t) == 'table' end
 local function isstring(t) return type(t) == 'string' end
 local function isnumber(t) return type(t) == 'number' end
 local function isbool(t) return type(t) == 'boolean' end
-local function ivector(t) return Vector ~= nil and getmetatable(t) == Vector end
+local function isvector(t) return Vector ~= nil and getmetatable(t) == Vector end
 local function isangle(t) return Angle ~= nil and getmetatable(t) == Angle end
 
 --[[---------------------------------------------------------

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -266,9 +266,7 @@ namespace GooseLua {
 
             KeyEnums.Load();
 
-
-            UserData.RegisterType<GooseProxy>();
-            UserData.RegisterType<VectorProxy>();
+            GooseProxy.Register();
             _G.LuaState.Globals["goose"] = new GooseProxy();
 
             InjectionPoints.PreTickEvent += preTick;

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -267,7 +267,7 @@ namespace GooseLua {
             KeyEnums.Load();
 
             GooseProxy.Register();
-            _G.LuaState.Globals["goose"] = new GooseProxy();
+            _G.LuaState.Globals["goose"] = new GooseProxy(_G.LuaState);
 
             InjectionPoints.PreTickEvent += preTick;
             InjectionPoints.PostTickEvent += postTick;

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -268,6 +268,9 @@ namespace GooseLua {
 
             GooseProxy.Register();
             _G.LuaState.Globals["goose"] = new GooseProxy(_G.LuaState);
+            _G.LuaState.Globals["GetModDirectory"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
+                return DynValue.NewString(API.Helper.getModDirectory(this));
+            });
 
             InjectionPoints.PreTickEvent += preTick;
             InjectionPoints.PostTickEvent += postTick;

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -282,20 +282,6 @@ namespace GooseLua {
             });
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
-
-            System.Windows.Forms.Timer timer = new System.Windows.Forms.Timer();
-            timer.Tick += timerTick;
-            timer.Interval = 1;
-            timer.Enabled = true;
-        }
-
-        public void timerTick(object s, EventArgs e) {
-            if (_G.luaQueue.Count > 0) {
-                string lua = _G.luaQueue[0];
-                _G.luaQueue.RemoveAt(0);
-                _G.RunString(lua);
-                
-            }
         }
 
         public void callHooks(string hook) {

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -266,7 +266,10 @@ namespace GooseLua {
 
             KeyEnums.Load();
 
-            InjectionPoints.PreRenderEvent += updateGoose;
+
+            UserData.RegisterType<GooseProxy>();
+            UserData.RegisterType<VectorProxy>();
+            _G.LuaState.Globals["goose"] = new GooseProxy();
 
             InjectionPoints.PreTickEvent += preTick;
             InjectionPoints.PostTickEvent += postTick;
@@ -297,56 +300,6 @@ namespace GooseLua {
             }
         }
 
-        public void updateGoose(GooseEntity g, dynamic _) {
-            _G.goose = g;
-            Table goose = new Table(_G.LuaState);
-            Table position = new Table(_G.LuaState);
-            position["x"] = g.position.x;
-            position["y"] = g.position.y;
-            goose["position"] = position;
-            goose["setTarget"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
-                int x = arguments.Count > 0 ? arguments.AsInt(0, "Goose.setTarget") : 0;
-                int y = arguments.Count > 1 ? arguments.AsInt(1, "Goose.setTarget") : 0;
-                g.targetPos = new SamEngine.Vector2(x, y);
-                return DynValue.Nil;
-            });
-
-            goose["setPosition"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
-                int x = arguments.Count > 0 ? arguments.AsInt(0, "Goose.setPosition") : 0;
-                int y = arguments.Count > 1 ? arguments.AsInt(1, "Goose.setPosition") : 0;
-                g.position = new SamEngine.Vector2(x, y);
-                return DynValue.Nil;
-            });
-
-            goose["getTasks"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
-                Table tasks = new Table(_G.LuaState);
-                foreach (string task in API.TaskDatabase.getAllLoadedTaskIDs()) {
-                    tasks.Append(DynValue.NewString(task));
-                }
-                return DynValue.NewTable(tasks);
-            });
-
-            goose["getTask"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
-                return DynValue.NewString(API.TaskDatabase.getAllLoadedTaskIDs()[g.currentTask]);
-            });
-
-            goose["setTask"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
-                string task = arguments.AsStringUsingMeta(context, 0, "Goose.setPosition");
-                bool honk = arguments.Count > 1 ? arguments.AsUserData<bool>(1, "Goose.setTask") : true;
-                bool valid = false;
-                foreach(string tsk in API.TaskDatabase.getAllLoadedTaskIDs()) {
-                    if(tsk == task) {
-                        valid = true;
-                    }
-                }
-                if (!valid) throw new ScriptRuntimeException("Unknown task \"" + task + "\".");
-                API.Goose.setCurrentTaskByID(g, task, honk);
-                return DynValue.Nil;
-            });
-
-            _G.LuaState.Globals["goose"] = goose;
-        }
-
         public void callHooks(string hook) {
             foreach (Closure func in _G.hook.hooks[hook].Values) {
                 try {
@@ -360,30 +313,36 @@ namespace GooseLua {
         }
 
         public void preTick(GooseEntity g) {
+            _G.goose = g;
             callHooks("preTick");
         }
 
         public void postTick(GooseEntity g) {
+            _G.goose = g;
             callHooks("postTick");
         }
 
         public void preRender(GooseEntity g, Graphics e) {
+            _G.goose = g;
             e.PixelOffsetMode = PixelOffsetMode.HighSpeed;
             graphics = e;
             callHooks("preRender");
         }
 
         public void postRender(GooseEntity g, Graphics e) {
+            _G.goose = g;
             e.PixelOffsetMode = PixelOffsetMode.HighSpeed;
             graphics = e;
             callHooks("postRender");
         }
 
         public void preRig(GooseEntity g) {
+            _G.goose = g;
             callHooks("preRig");
         }
 
         public void postRig(GooseEntity g) {
+            _G.goose = g;
             callHooks("postRig");
         }
     }

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -269,7 +269,7 @@ namespace GooseLua {
             GooseProxy.Register();
             _G.LuaState.Globals["goose"] = new GooseProxy(_G.LuaState);
             _G.LuaState.Globals["GetModDirectory"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
-                return DynValue.NewString(API.Helper.getModDirectory(this));
+                return DynValue.NewString(_G.path);
             });
 
             InjectionPoints.PreTickEvent += preTick;

--- a/DefaultMod/formLoader.cs
+++ b/DefaultMod/formLoader.cs
@@ -80,7 +80,8 @@ namespace GooseLua {
                 int len = modFile.Length;
                 modList.Items.Add(modFile.Substring(0, len - 4));
                 try {
-                    _G.luaQueue.Add(File.ReadAllText(mod));
+                    string code = File.ReadAllText(mod);
+                    _G.RunString(code, modFile);
                 } catch (ScriptRuntimeException ex) {
                     Util.MsgC(this, Color.FromArgb(255, 0, 0), string.Format("Doh! An error occured! {0}", ex.DecoratedMessage), "\r\n");
                 }
@@ -112,7 +113,8 @@ namespace GooseLua {
                 int len = argstable.Length;
                 if (args.Count > 0) argstable = argstable.Substring(0, len - 2);
                 argstable += '}';
-                _G.luaQueue.Add("print(\"] " + safe + " " + string.Join(" ", args) + "\") concommand.Run(\"" + safe + "\", " + argstable + ")");
+                string code = "print(\"] " + safe + " " + string.Join(" ", args) + "\") concommand.Run(\"" + safe + "\", " + argstable + ")";
+                _G.RunString(code, "console");
                 metroTextBox1.Clear();
             }
         }


### PR DESCRIPTION
This exposes most of the modding API to Lua, using proxy objects. Docs will come soon™.

This allows things like:
```lua
hook.Add("postRig", "stuff", function()
   print("goose position", goose.position.x, goose.position.y)
   print("UnderBodyRadius", goose.rig.UnderBodyRadius)
   print("BodyCenter", goose.rig.bodyCenter.x, goose.rig.bodyCenter.y)
   goose.rig.bodyCenter.x = 100
   goose.rig.feets.rFootPos.x = 80
   goose.rig.feets.lFootPos = {120,120}
end)
```

Vectors can be assigned from lists (`{12,34}`) or tables (`{x = 1, y = 2}`), or their components can be assigned individually (eg `goose.position.x = 123`).
When reading a vector, it will return a table with `x` and `y` elements.

Also, it removes the 1ms timer that was used to run code, since it's very cpu-heavy and not needed.

I have dual-licensed the new `GooseProxy.cs` file under GPL and MIT, since I intend to use it in the Mac version to support Lua mods natively.