### PR TITLE
draw and surface API

### DIFF
--- a/DefaultMod/Lua/Draw.cs
+++ b/DefaultMod/Lua/Draw.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Drawing.Drawing2D;
 using MoonSharp.Interpreter;
 
 namespace GooseLua.Lua
@@ -12,31 +9,185 @@ namespace GooseLua.Lua
     class Draw
     {
         private Script script;
+        private Surface surface;
         private Graphics graphics { get => _G.graphics; }
 
         [MoonSharpHidden]
-        public Draw(Script script)
+        public Draw(Script script, Surface surface)
         {
             this.script = script;
+            this.surface = surface;
         }
 
-        public void SimpleText(string text, string font, int x, int y) {
-            if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid _G.hook.");
-            graphics.DrawString(text, new Font(font, 12f), Brushes.White, new PointF(x, y));
+        private void CheckGraphics() {
+            if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid hook.");
         }
 
-        public void SimpleTextOutlined (string text, string font, int x, int y) => SimpleText(text, font, x, y);
-        
+        private Color GetColor(Table color, Color defaultColor) {
+            if (color == null) {
+                return defaultColor;
+            }
+            int r = (int)color.Get("r").Number;
+            int g = (int)color.Get("g").Number;
+            int b = (int)color.Get("b").Number;
+            int a = (int)color.Get("a").Number;
+            Util.Clamp(ref r, 0, 255);
+            Util.Clamp(ref g, 0, 255);
+            Util.Clamp(ref b, 0, 255);
+            Util.Clamp(ref a, 0, 255);
+
+            return Color.FromArgb(a, r, g, b);
+        }
+
+        private StringFormat GetStringFormat(int xAlign, int yAlign) {
+            var format = new StringFormat();
+            switch (xAlign) {
+                case (int)TextAlign.TEXT_ALIGN_RIGHT:
+                    format.Alignment = StringAlignment.Far;
+                    break;
+                case (int)TextAlign.TEXT_ALIGN_CENTER:
+                    format.Alignment = StringAlignment.Center;
+                    break;
+                case (int)TextAlign.TEXT_ALIGN_LEFT:
+                default:
+                    format.Alignment = StringAlignment.Near;
+                    break;
+            }
+            switch (yAlign) {
+                case (int)TextAlign.TEXT_ALIGN_BOTTOM:
+                    format.LineAlignment = StringAlignment.Far;
+                    break;
+                case (int)TextAlign.TEXT_ALIGN_CENTER:
+                    format.LineAlignment = StringAlignment.Center;
+                    break;
+
+                case (int)TextAlign.TEXT_ALIGN_TOP:
+                default:
+                    format.LineAlignment = StringAlignment.Near;
+                    break;
+            }
+            return format;
+        }
+        public void DrawText(string text, string font = "DermaDefault", int x = 0, int y = 0, Table color = null, int xAlign = (int)TextAlign.TEXT_ALIGN_LEFT) => SimpleText(text, font, x, y, color, xAlign);
+
         public float GetFontHeight(string font) {
-            if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid _G.hook.");
-            return graphics.MeasureString("A", new Font(font, 12f)).Height;
+            CheckGraphics();
+            return surface.GetFont(font).Height;
         }
 
+        public void RoundedBox(int cornerRadius, int x, int y, int width, int height, Table color) => RoundedBoxEx(cornerRadius, x, y, width, height, color, true, true, true, true);
+
+        public void RoundedBoxEx(int cornerRadius, int x, int y, int width, int height, Table color, bool roundTopLeft = false, bool roundTopRight = false, bool roundBottomLeft = false, bool roundBottomRight = false) {
+            CheckGraphics();
+            int diameter = cornerRadius * 2;
+            Rectangle arc = new Rectangle(x, y, diameter, diameter);
+            GraphicsPath path = new GraphicsPath();
+
+            if (roundTopLeft) {
+                path.AddArc(arc, 180, 90);
+            } else {
+                path.AddLine(x, y, x, y);
+            }
+
+            arc.X = x + width - diameter;
+            if (roundTopRight) {
+                path.AddArc(arc, 270, 90);
+            } else {
+                path.AddLine(x + cornerRadius, y, x + width, y);
+            }
+
+            arc.Y = y + height - diameter;
+            if (roundBottomRight) {
+                path.AddArc(arc, 0, 90);
+            } else {
+                path.AddLine(x + width, y + height - cornerRadius, x + width, y + height);
+            }
+
+            arc.X = x;
+            if (roundBottomLeft) {
+                path.AddArc(arc, 90, 90);
+            } else {
+                path.AddLine(x + width - cornerRadius, y + height, x, y + height);
+            }
+
+            path.CloseFigure();
+
+            graphics.FillPath(new SolidBrush(GetColor(color, Color.White)), path);
+        }
+
+        public DynValue SimpleText(string text, string font = "DermaDefault", int x = 0, int y = 0, Table color = null, int xAlign = (int)TextAlign.TEXT_ALIGN_LEFT, int yAlign = (int)TextAlign.TEXT_ALIGN_TOP) {
+            var pos = new Point(x, y);
+            var format = GetStringFormat(xAlign, yAlign);
+            var textColor = GetColor(color, Color.White);
+
+            var textFont = surface.GetFont(font);
+            graphics.DrawString(text, textFont, new SolidBrush(textColor), pos, format);
+
+            var size = graphics.MeasureString(text, textFont, pos, format);
+            return DynValue.NewTuple(DynValue.NewNumber(size.Width), DynValue.NewNumber(size.Height));
+        }
+
+        public DynValue SimpleTextOutlined(string text, string font = "DermaDefault", int x = 0, int y = 0, Table color = null, int xAlign = (int)TextAlign.TEXT_ALIGN_LEFT, int yAlign = (int)TextAlign.TEXT_ALIGN_TOP, double outlineWidth = 1, Table outlineColor = null) {
+            CheckGraphics();
+            var path = new GraphicsPath();
+            var textFont = surface.GetFont(font);
+            var pos = new Point(x, y);
+            var format = GetStringFormat(xAlign, yAlign);
+            var fillColor = GetColor(color, Color.White);
+            var textOutlineColor = GetColor(outlineColor, Color.White);
+            path.AddString(text, textFont.FontFamily, (int)textFont.Style, textFont.Size, pos, format);
+
+            if (fillColor.A > 0) {
+                graphics.FillPath(new SolidBrush(fillColor), path);
+            }
+            graphics.DrawPath(new Pen(textOutlineColor, (float)outlineWidth), path);
+
+            var size = graphics.MeasureString(text, textFont, pos, format);
+            return DynValue.NewTuple(DynValue.NewNumber(size.Width), DynValue.NewNumber(size.Height));
+        }
+
+        public DynValue Text(Table tab) {
+            return SimpleText(
+                tab.Get("text").String,
+                tab.Get("font")?.String ?? "DermaDefault",
+                (int)(tab.Get("pos")?.Table.Get(1).Number ?? 0),
+                (int)(tab.Get("pos")?.Table.Get(2).Number ?? 0),
+                tab.Get("color")?.Table,
+                (int)(tab.Get("xalign")?.Number ?? (int)TextAlign.TEXT_ALIGN_LEFT),
+                (int)(tab.Get("yalign")?.Number ?? (int)TextAlign.TEXT_ALIGN_TOP)
+                );
+        }
+
+        public DynValue TextShadow(Table tab, double distance, int alpha = 200) {
+            Util.Clamp(ref alpha, 0, 255);
+            return SimpleText(
+                tab.Get("text").String,
+                tab.Get("font")?.String ?? "DermaDefault",
+                (int)(tab.Get("pos")?.Table.Get(1).Number ?? 0),
+                (int)(tab.Get("pos")?.Table.Get(2).Number ?? 0),
+                script.DoString($"Color(0,0,0,{alpha})").Table,
+                (int)(tab.Get("xalign")?.Number ?? (int)TextAlign.TEXT_ALIGN_LEFT),
+                (int)(tab.Get("yalign")?.Number ?? (int)TextAlign.TEXT_ALIGN_TOP)
+                );
+        }
+
+        public DynValue WordBox(int borderSize, int x, int y, string text, string font, Table boxColor, Table textColor) {
+            var textFont = surface.GetFont(font);
+            var size = graphics.MeasureString(text, textFont);
+
+            RoundedBox(borderSize, x, y, (int)size.Width + borderSize * 2, (int)size.Height + borderSize * 2, boxColor);
+            graphics.DrawString(text, textFont, new SolidBrush(GetColor(textColor, Color.White)), x + borderSize, y + borderSize);
+
+            return DynValue.NewTuple(DynValue.NewNumber(size.Width + borderSize * 2), DynValue.NewNumber(size.Height + borderSize * 2));
+        }
+
+        #region non-facepunch API
         public DynValue MeasureText(string text, string font = "Segoe UI Light")
         {
             if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid _G.hook.");
             SizeF size = graphics.MeasureString(text, new Font(font, 12f));
             return DynValue.NewTable(new Table(_G.LuaState, DynValue.NewNumber(size.Width), DynValue.NewNumber(size.Height)));
         }
+        #endregion
     }
 }

--- a/DefaultMod/Lua/Draw.cs
+++ b/DefaultMod/Lua/Draw.cs
@@ -23,22 +23,6 @@ namespace GooseLua.Lua
             if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid hook.");
         }
 
-        private Color GetColor(Table color, Color defaultColor) {
-            if (color == null) {
-                return defaultColor;
-            }
-            int r = (int)color.Get("r").Number;
-            int g = (int)color.Get("g").Number;
-            int b = (int)color.Get("b").Number;
-            int a = (int)color.Get("a").Number;
-            Util.Clamp(ref r, 0, 255);
-            Util.Clamp(ref g, 0, 255);
-            Util.Clamp(ref b, 0, 255);
-            Util.Clamp(ref a, 0, 255);
-
-            return Color.FromArgb(a, r, g, b);
-        }
-
         private StringFormat GetStringFormat(int xAlign, int yAlign) {
             var format = new StringFormat();
             switch (xAlign) {
@@ -112,13 +96,13 @@ namespace GooseLua.Lua
 
             path.CloseFigure();
 
-            graphics.FillPath(new SolidBrush(GetColor(color, Color.White)), path);
+            graphics.FillPath(new SolidBrush(Surface.GetColor(color, Color.White)), path);
         }
 
         public DynValue SimpleText(string text, string font = "DermaDefault", int x = 0, int y = 0, Table color = null, int xAlign = (int)TextAlign.TEXT_ALIGN_LEFT, int yAlign = (int)TextAlign.TEXT_ALIGN_TOP) {
             var pos = new Point(x, y);
             var format = GetStringFormat(xAlign, yAlign);
-            var textColor = GetColor(color, Color.White);
+            var textColor = Surface.GetColor(color, Color.White);
 
             var textFont = surface.GetFont(font);
             graphics.DrawString(text, textFont, new SolidBrush(textColor), pos, format);
@@ -133,8 +117,8 @@ namespace GooseLua.Lua
             var textFont = surface.GetFont(font);
             var pos = new Point(x, y);
             var format = GetStringFormat(xAlign, yAlign);
-            var fillColor = GetColor(color, Color.White);
-            var textOutlineColor = GetColor(outlineColor, Color.White);
+            var fillColor = Surface.GetColor(color, Color.White);
+            var textOutlineColor = Surface.GetColor(outlineColor, Color.White);
             path.AddString(text, textFont.FontFamily, (int)textFont.Style, textFont.Size, pos, format);
 
             if (fillColor.A > 0) {
@@ -176,7 +160,7 @@ namespace GooseLua.Lua
             var size = graphics.MeasureString(text, textFont);
 
             RoundedBox(borderSize, x, y, (int)size.Width + borderSize * 2, (int)size.Height + borderSize * 2, boxColor);
-            graphics.DrawString(text, textFont, new SolidBrush(GetColor(textColor, Color.White)), x + borderSize, y + borderSize);
+            graphics.DrawString(text, textFont, new SolidBrush(Surface.GetColor(textColor, Color.White)), x + borderSize, y + borderSize);
 
             return DynValue.NewTuple(DynValue.NewNumber(size.Width + borderSize * 2), DynValue.NewNumber(size.Height + borderSize * 2));
         }

--- a/DefaultMod/Lua/Draw.cs
+++ b/DefaultMod/Lua/Draw.cs
@@ -166,10 +166,9 @@ namespace GooseLua.Lua
         }
 
         #region non-facepunch API
-        public DynValue MeasureText(string text, string font = "Segoe UI Light")
-        {
-            if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid _G.hook.");
-            SizeF size = graphics.MeasureString(text, new Font(font, 12f));
+        public DynValue MeasureText(string text, string font = "DermaDefault") {
+            CheckGraphics();
+            SizeF size = graphics.MeasureString(text, surface.GetFont(font));
             return DynValue.NewTable(new Table(_G.LuaState, DynValue.NewNumber(size.Width), DynValue.NewNumber(size.Height)));
         }
         #endregion

--- a/DefaultMod/Lua/Enums.cs
+++ b/DefaultMod/Lua/Enums.cs
@@ -12,6 +12,7 @@ namespace GooseLua.Lua
         public static void Register(Script script)
         {
             RegisterEnum(typeof(Mouse), script);
+            RegisterEnum(typeof(TextAlign), script);
         }
 
         public static void RegisterEnum(Type type, Script script, string prefix = "")
@@ -36,5 +37,14 @@ namespace GooseLua.Lua
         MOUSE_WHEEL_DOWN = 113,
         MOUSE_LAST = 113,
         MOUSE_COUNT = 7
+    }
+
+    enum TextAlign
+    {
+        TEXT_ALIGN_LEFT = 0,
+        TEXT_ALIGN_CENTER = 1,
+        TEXT_ALIGN_RIGHT = 2,
+        TEXT_ALIGN_TOP = 3,
+        TEXT_ALIGN_BOTTOM = 4
     }
 }

--- a/DefaultMod/Lua/Hook.cs
+++ b/DefaultMod/Lua/Hook.cs
@@ -1,14 +1,34 @@
 ﻿using MoonSharp.Interpreter;
+using System;
 using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
 
 namespace GooseLua.Lua {
     [MoonSharpUserData]
     class Hook {
         [MoonSharpHidden]
-        public Dictionary<string, Dictionary<string, Closure>> hooks = new Dictionary<string, Dictionary<string, Closure>>();
-        
+        public formLoader form;
+        private Dictionary<string, Dictionary<string, Closure>> hooks = new Dictionary<string, Dictionary<string, Closure>>();
+        private List<Tuple<string, string, Closure>> deferredUpdates = new List<Tuple<string, string, Closure>>();
+        private bool callingHooks = false;
+
+        public Hook() {
+            hooks["preRig"] = new Dictionary<string, Closure>();
+            hooks["postRig"] = new Dictionary<string, Closure>();
+            hooks["preTick"] = new Dictionary<string, Closure>();
+            hooks["postTick"] = new Dictionary<string, Closure>();
+            hooks["preRender"] = new Dictionary<string, Closure>();
+            hooks["postRender"] = new Dictionary<string, Closure>();
+        }
+
         public void Add(string hook, string name, Closure action) {
-            if(hooks[hook].ContainsKey(name)) {
+            if (callingHooks) {
+                // defer update
+                deferredUpdates.Add(Tuple.Create(hook, name, action));
+                return;
+            }
+            if (hooks[hook].ContainsKey(name)) {
                 hooks[hook][name] = action;
             } else {
                 hooks[hook].Add(name, action);
@@ -16,7 +36,39 @@ namespace GooseLua.Lua {
         }
 
         public void Remove(string hook, string name) {
+            if (callingHooks) {
+                // defer update
+                deferredUpdates.Add(Tuple.Create(hook, name, default(Closure)));
+                return;
+            }
             hooks[hook].Remove(name);
+        }
+
+        [MoonSharpHidden]
+        public void CallHooks(string hook) {
+            callingHooks = true;
+            foreach (Closure func in hooks[hook].Values) {
+                try {
+                    func.Call();
+                } catch (InterpreterException ex) {
+                    Util.MsgC(form, Color.FromArgb(255, 0, 0), string.Format("[ERROR] {0}: {1}\r\n{2}", ex.Source, ex.DecoratedMessage, ex.StackTrace), "\r\n");
+                } catch (Exception ex) {
+                    MessageBox.Show(ex.ToString(), ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+            callingHooks = false;
+            RunDeferredUpdates();
+        }
+
+        private void RunDeferredUpdates() {
+            foreach(var update in deferredUpdates) {
+                if (update.Item3 == default(Closure)) {
+                    Remove(update.Item1, update.Item2);
+                } else {
+                    Add(update.Item1, update.Item2, update.Item3);
+                }
+            }
+            deferredUpdates.Clear();
         }
     }
 }

--- a/DefaultMod/Lua/Surface.cs
+++ b/DefaultMod/Lua/Surface.cs
@@ -136,7 +136,8 @@ namespace GooseLua.Lua
 
         public void DrawCircle(int originX, int originY, int radius, DynValue rOrColor, int g = 255, int b = 255, int a = 255) {
             CheckGraphics();
-            graphics.DrawEllipse(drawPen, new Rectangle(originX - radius, originY - radius, 2*radius, 2*radius));
+            var pen = new Pen(GetColor(rOrColor, g, b, a));
+            graphics.DrawEllipse(pen, new Rectangle(originX - radius, originY - radius, 2*radius, 2*radius));
         }
 
         public void DrawLine(int sx, int sy, int fx, int fy) {

--- a/DefaultMod/Lua/Surface.cs
+++ b/DefaultMod/Lua/Surface.cs
@@ -1,4 +1,7 @@
-﻿using System.Drawing;
+﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Media;
 using MoonSharp.Interpreter;
 
 namespace GooseLua.Lua
@@ -8,31 +11,179 @@ namespace GooseLua.Lua
     {
         private Script script;
         private Graphics graphics { get => _G.graphics; }
-        private Color drawColor = Color.FromArgb(255, 255, 255);
+        private Color drawColor = Color.White;
+        private Pen drawPen = new Pen(new SolidBrush(Color.White));
+        private Dictionary<string, Font> fonts = new Dictionary<string, Font>();
+        private Closure isColor = null;
+        private Point textPos = Point.Empty;
+        private Color textColor = Color.White;
+        private Font textFont = null;
+        private Dictionary<string, SoundPlayer> sounds = new Dictionary<string, SoundPlayer>();
 
         [MoonSharpHidden]
         public Surface(Script script)
         {
             this.script = script;
+            InitFonts();
         }
 
-        public void SetDrawColor(int r, int g, int b, int a = 255) {
-            if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid hook.");
+        [MoonSharpHidden]
+        public Font GetFont(string name) => fonts.ContainsKey(name) ? fonts[name] : fonts["Default"];
+
+        private void InitFonts() {
+            CreateFont("DermaDefault", "Tahoma", 13f);
+            CreateFont("DermaDefaultBold", "Tahoma", 13f, FontStyle.Bold);
+            CreateFont("DermaLarge", "Tahoma", 32f);
+            CreateFont("DebugFixed", "Courier New", 14f);
+            CreateFont("DebugFixedSmall", "Courier New", 14f);
+            CreateFont("Default", "Verdana", 12f);
+            CreateFont("Marlett", "Marlett", 14f);
+            CreateFont("Trebuchet18", "Trebuchet MS", 18f);
+            CreateFont("Trebuchet24", "Trebuchet MS", 24f);
+            CreateFont("HudHintTextLarge", "Verdana", 14f);
+            CreateFont("HudHintTextSmall", "Verdana", 11f);
+            CreateFont("CenterPrintText", "Trebuchet MS", 18f);
+            CreateFont("HudSelectionText", "Verdana", 8f);
+            CreateFont("CloseCaption_Normal", "Tahoma", 26f);
+            CreateFont("CloseCaption_Italic", "Tahoma", 26f, FontStyle.Italic);
+            CreateFont("CloseCaption_Bold", "Tahoma", 26f, FontStyle.Bold);
+            CreateFont("CloseCaption_BoldItalic", "Tahoma", 26f, FontStyle.Bold | FontStyle.Italic);
+            CreateFont("TargetID", "Trebuchet MS", 24f, FontStyle.Bold);
+            CreateFont("TargetIDSmall", "Trebuchet MS", 18f, FontStyle.Bold);
+            CreateFont("BudgetLabel", "Courier New", 14f);
+            CreateFont("HudNumbers", "Trebuchet MS", 32f);
+            SetFont("Default");
+        }
+
+        private Color GetColor(DynValue rOrColor, int g, int b, int a) {
+            if (isColor == null) {
+                isColor = (Closure)script.Globals["IsColor"];
+            }
+
+            int r;
+
+            if (isColor.Call(rOrColor).CastToBool()) {
+                Table color = rOrColor.Table;
+                r = (int)color.Get("r").Number;
+                g = (int)color.Get("g").Number;
+                b = (int)color.Get("b").Number;
+                a = (int)color.Get("a").Number;
+            } else {
+                r = (int)(rOrColor.CastToNumber() ?? 255.0);
+            }
+
             Util.Clamp(ref r, 0, 255);
             Util.Clamp(ref g, 0, 255);
             Util.Clamp(ref b, 0, 255);
             Util.Clamp(ref a, 0, 255);
-            drawColor = Color.FromArgb(a, r, g, b);
+
+            return Color.FromArgb(a, r, g, b);
+        }
+
+        private Table GetColorTable(Color color) {
+            return script.DoString($"Color({color.R},{color.G},{color.B},{color.A})").Table;
+        }
+
+        private void CheckGraphics() {
+            if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid hook.");
+        }
+
+        public void CreateFont(string name, Table attributes) {
+            FontStyle style = FontStyle.Regular;
+            double size = attributes.Get("size")?.CastToNumber() ?? 13.0;
+            double weight = attributes.Get("weight")?.CastToNumber() ?? 400;
+            if (attributes.Get("underline").CastToBool()) {
+                style |= FontStyle.Underline;
+            }
+            if (attributes.Get("italic").CastToBool()) {
+                style |= FontStyle.Italic;
+            }
+            if (attributes.Get("bold").CastToBool() || weight >= 600 ) {
+                style |= FontStyle.Bold;
+            }
+            if (attributes.Get("strikeout").CastToBool()) {
+                style |= FontStyle.Strikeout;
+            }
+
+            CreateFont(name, attributes.Get("font").CastToString(), (float)size, style);
+        }
+
+        private void CreateFont(string fontKey, string fontName, float size, FontStyle style = FontStyle.Regular) {
+            var font = new Font(fontName, size, style);
+            if (fonts.ContainsKey(fontKey)) {
+                fonts.Remove(fontKey);
+            }
+            fonts.Add(fontKey, font);
+        }
+
+        public void DrawCircle(int originX, int originY, int radius, DynValue rOrColor, int g = 255, int b = 255, int a = 255) {
+            CheckGraphics();
+            graphics.DrawEllipse(drawPen, new Rectangle(originX - radius, originY - radius, 2*radius, 2*radius));
         }
 
         public void DrawLine(int sx, int sy, int fx, int fy) {
-            if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid hook.");
-            graphics.DrawLine(new Pen(new SolidBrush(drawColor), 1f), sx, sy, fx, fy);
+            CheckGraphics();
+            graphics.DrawLine(drawPen, sx, sy, fx, fy);
+        }
+
+        public void DrawOutlinedRect(int x, int y, int w, int h) {
+            CheckGraphics();
+            graphics.DrawRectangle(drawPen, x, y, w, h);
+        }
+
+        public void DrawPoly(Table vertices) {
+            CheckGraphics();
+            var points = vertices.Pairs.Select(v =>
+                new PointF((float)v.Value.Table.Get("x").Number, (float)v.Value.Table.Get("y").Number)
+            ).ToArray<PointF>();
+            graphics.FillPolygon(new SolidBrush(drawColor), points);
+        }
+
+        public void DrawRect(int x, int y, int w, int h) {
+            CheckGraphics();
+            graphics.FillRectangle(new SolidBrush(drawColor), new Rectangle(x, y, w, h));
+        }
+        public void DrawText(string text) {
+            CheckGraphics();
+            graphics.DrawString(text, textFont, new SolidBrush(textColor), textPos);
+        }
+
+        public Table GetDrawColor() {
+            return GetColorTable(drawColor);
+        }
+        public Table GetTextColor() {
+            return GetColorTable(textColor);
+        }
+
+        public DynValue GetTextSize(string text) {
+            if (graphics == default(Graphics) || textFont == null) {
+                return DynValue.Nil;
+            }
+            SizeF size = graphics.MeasureString(text, textFont);
+            return DynValue.NewTuple(DynValue.NewNumber(size.Width), DynValue.NewNumber(size.Height));
+        }
+
+        public void PlaySound(string soundfile) {
+            if (!sounds.TryGetValue(soundfile, out SoundPlayer player)) {
+                player = new SoundPlayer(soundfile);
+                sounds.Add(soundfile, player);
+            }
+            player.Play();
+        }
+        public void SetDrawColor(DynValue rOrColor, int g = 255, int b = 255, int a = 255) {
+            drawColor = GetColor(rOrColor, g, b, a);
         }
         
-        public void DrawRect(int x, int y, int h, int w) {
-            if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid hook.");
-            graphics.FillRectangle(new SolidBrush(drawColor), new Rectangle(x, y, h, w));
+        public void SetFont(string fontName) {
+            textFont = GetFont(fontName);
+        }
+
+        public void SetTextColor(DynValue rOrColor, int g = 255, int b = 255, int a = 255) {
+            textColor = GetColor(rOrColor, g, b, a);
+        }
+
+        public void SetTextPos(int x, int y) {
+            textPos = new Point(x, y);
         }
     }
 }

--- a/DefaultMod/Lua/Surface.cs
+++ b/DefaultMod/Lua/Surface.cs
@@ -80,9 +80,27 @@ namespace GooseLua.Lua
             return Color.FromArgb(a, r, g, b);
         }
 
-        private Table GetColorTable(Color color) {
+        public static Color GetColor(Table color, Color? defaultColor = null) {
+            if (color == null) {
+                return defaultColor.GetValueOrDefault();
+            }
+            int r = (int)color.Get("r").Number;
+            int g = (int)color.Get("g").Number;
+            int b = (int)color.Get("b").Number;
+            int a = (int)color.Get("a").Number;
+            Util.Clamp(ref r, 0, 255);
+            Util.Clamp(ref g, 0, 255);
+            Util.Clamp(ref b, 0, 255);
+            Util.Clamp(ref a, 0, 255);
+
+            return Color.FromArgb(a, r, g, b);
+        }
+
+        public static Table GetColorTable(Script script, Color color) {
             return script.DoString($"Color({color.R},{color.G},{color.B},{color.A})").Table;
         }
+
+        private Table GetColorTable(Color color) => GetColorTable(script, color);
 
         private void CheckGraphics() {
             if (graphics == default(Graphics)) throw new ScriptRuntimeException("Graphics not initialized or invalid hook.");

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -118,6 +118,9 @@ namespace GooseLua {
             _G.LuaState.Globals["GetModDirectory"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
                 return DynValue.NewString(_G.path);
             });
+            _G.LuaState.Globals["CurTime"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
+                return DynValue.NewNumber(SamEngine.Time.time);
+            });
 
             _G.LuaState.Globals["RegisterTask"] = CallbackFunction.FromMethodInfo(_G.LuaState, typeof(Task).GetMethod("Register"));
 

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -16,13 +16,6 @@ namespace GooseLua {
         void IMod.Init() {
             _G.path = Path.GetFullPath(Path.Combine(API.Helper.getModDirectory(this), "..", "..", "Lua Mods"));
 
-            _G.hook.hooks["preRig"] = new Dictionary<string, Closure>();
-            _G.hook.hooks["postRig"] = new Dictionary<string, Closure>();
-            _G.hook.hooks["preTick"] = new Dictionary<string, Closure>();
-            _G.hook.hooks["postTick"] = new Dictionary<string, Closure>();
-            _G.hook.hooks["preRender"] = new Dictionary<string, Closure>();
-            _G.hook.hooks["postRender"] = new Dictionary<string, Closure>();
-
             _G.LuaState.Globals["ScrW"] = new CallbackFunction((ScriptExecutionContext context, CallbackArguments arguments) => {
                 return DynValue.NewNumber(Screen.PrimaryScreen.Bounds.Width);
             });
@@ -38,6 +31,7 @@ namespace GooseLua {
             _G.LuaState.Globals["draw"] = new Lua.Draw(_G.LuaState, surface);
             _G.LuaState.Globals["surface"] = surface;
             _G.LuaState.Globals["hook"] = _G.hook;
+            _G.hook.form = form;
             _G.LuaState.Globals["input"] = new Lua.Input(_G.LuaState);
             _G.LuaState.Globals["Msg"] = _G.LuaState.Globals["print"];
 
@@ -151,50 +145,38 @@ namespace GooseLua {
             }
         }
 
-        public void callHooks(string hook) {
-            foreach (Closure func in _G.hook.hooks[hook].Values) {
-                try {
-                    func.Call();
-                } catch(InterpreterException ex) {
-                    Util.MsgC(form, Color.FromArgb(255, 0, 0), string.Format("[ERROR] {0}: {1}\r\n{2}", ex.Source, ex.DecoratedMessage, ex.StackTrace), "\r\n");
-                } catch(Exception ex) {
-                    MessageBox.Show(ex.ToString(), ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-            }
-        }
-
         public void preTick(GooseEntity g) {
             _G.goose = g;
-            callHooks("preTick");
+            _G.hook.CallHooks("preTick");
         }
 
         public void postTick(GooseEntity g) {
             _G.goose = g;
-            callHooks("postTick");
+            _G.hook.CallHooks("postTick");
         }
 
         public void preRender(GooseEntity g, Graphics e) {
             _G.goose = g;
             _G.graphics = e;
             e.PixelOffsetMode = PixelOffsetMode.HighSpeed;
-            callHooks("preRender");
+            _G.hook.CallHooks("preRender");
         }
 
         public void postRender(GooseEntity g, Graphics e) {
             _G.goose = g;
             _G.graphics = e;
             e.PixelOffsetMode = PixelOffsetMode.HighSpeed;
-            callHooks("postRender");
+            _G.hook.CallHooks("postRender");
         }
 
         public void preRig(GooseEntity g) {
             _G.goose = g;
-            callHooks("preRig");
+            _G.hook.CallHooks("preRig");
         }
 
         public void postRig(GooseEntity g) {
             _G.goose = g;
-            callHooks("postRig");
+            _G.hook.CallHooks("postRig");
         }
     }
 }

--- a/DefaultMod/ModMain.cs
+++ b/DefaultMod/ModMain.cs
@@ -34,8 +34,9 @@ namespace GooseLua {
             UserData.RegisterAssembly();
             Lua.Enums.Register(_G.LuaState);
 
-            _G.LuaState.Globals["draw"] = new Lua.Draw(_G.LuaState);
-            _G.LuaState.Globals["surface"] = new Lua.Surface(_G.LuaState);
+            Lua.Surface surface = new Lua.Surface(_G.LuaState);
+            _G.LuaState.Globals["draw"] = new Lua.Draw(_G.LuaState, surface);
+            _G.LuaState.Globals["surface"] = surface;
             _G.LuaState.Globals["hook"] = _G.hook;
             _G.LuaState.Globals["input"] = new Lua.Input(_G.LuaState);
             _G.LuaState.Globals["Msg"] = _G.LuaState.Globals["print"];


### PR DESCRIPTION
* adds almost all the functions from the [`draw`](https://wiki.facepunch.com/gmod/draw) and [`surface`](https://wiki.facepunch.com/gmod/surface) libraries from Garry's Mod, except the Texture related API.
* adds [`CurTime`](https://wiki.facepunch.com/gmod/Global.CurTime) function.
* adds the `goose` library to allow changing the colors.
* fixes invalid operation exception when calling hook.Add or hook.Remove from within a hook

Examples:
```lua
-- change goose colors
hook.Add("preRender", "ChangeGooseColors", function()
    -- must be done in a hook because the goose isn't available until after mods are initialised
    goose.renderData.gooseWhite = Color(128, 128, 128)
    goose.renderData.gooseOrange = Color(255, 0, 0)
    goose.renderData.gooseOutline = Color(255, 255, 255)
    goose.renderData.gooseShadow = Color(255, 0, 0)
    
    hook.Remove("preRender", "ChangeGooseColors")
end )

-- draw a circle with varying size
hook.Add( "preRender", "DrawCircleExample", function()
    surface.DrawCircle( 500, 500, 100 + math.sin( CurTime() ) * 50, Color( 255, 120, 0 ) )
end )
```
